### PR TITLE
Add missing include <iostream>

### DIFF
--- a/src_number/NumberTheoryBoostGmpInt.h
+++ b/src_number/NumberTheoryBoostGmpInt.h
@@ -7,7 +7,7 @@
 #include "TemplateTraits.h"
 #include "ExceptionEnding.h"
 #include "boost_serialization.h"
-
+#include <iostream>
 
 template <>
 struct is_boost_mpz_int<boost::multiprecision::mpz_int> {


### PR DESCRIPTION
Fixes a compile error triggered by line 293: `std::cerr << "Some error somewhere\n";`